### PR TITLE
Added non-trivial MarginCalculator test cases.

### DIFF
--- a/tests/MarginCalculatorTest.php
+++ b/tests/MarginCalculatorTest.php
@@ -208,7 +208,9 @@ class MarginCalculatorTest extends TestCase
         $registry = $this->instance->calculate(
             ...$nBallots
         );
+        // N(N-1)
         $this->assertEquals(2, $registry->getCount());
+        //check that Alice is ahead of Bob
         $this->assertEquals(1, $registry->get($this->alice, $this->bob)->getMargin());
         $this->assertEquals(-1, $registry->get($this->bob, $this->alice)->getMargin());
     }
@@ -226,8 +228,106 @@ class MarginCalculatorTest extends TestCase
         $registry = $this->instance->calculate(
             ...$nBallots
         );
+        // N(N-1)
         $this->assertEquals(2, $registry->getCount());
+        // check that Alice and Bob are tied
         $this->assertEquals(0, $registry->get($this->alice, $this->bob)->getMargin());
         $this->assertEquals(0, $registry->get($this->bob, $this->alice)->getMargin());
+    }
+    public function testCalculateForTiedPairOfCandidatesAheadOfNonTiedCandidate() : void
+    {
+        $ballotCount = 42;
+        $nBallots = [
+            new NBallot(
+                $ballotCount,
+                new CandidateList(
+                    $this->alice,
+                    $this->bob
+                ),
+                new CandidateList(
+                    $this->claire
+                )
+            )
+        ];
+        $registry = $this->instance->calculate(
+            ...$nBallots
+        );
+        // N(N-1)
+        $this->assertEquals(6, $registry->getCount());
+        //check that tied candidates' margins reflect that they are tied
+        $this->assertEquals(0, $registry->get($this->alice, $this->bob)->getMargin());
+        $this->assertEquals(0, $registry->get($this->bob, $this->alice)->getMargin());
+        //check that the margins indicate that Claire is ranked behind Alice and Bob
+        $this->assertEquals($ballotCount, $registry->get($this->alice, $this->claire)->getMargin());
+        $this->assertEquals($ballotCount, $registry->get($this->bob, $this->claire)->getMargin());
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->claire, $this->alice)->getMargin());
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->claire, $this->bob)->getMargin());
+    }
+    public function testCalculateForTiedPairOfCandidatesBehindNonTiedCandidate() : void
+    {
+        $ballotCount = 31;
+        $nBallots = [
+            new NBallot(
+                $ballotCount,
+                new CandidateList(
+                    $this->claire
+                ),
+                new CandidateList(
+                    $this->alice,
+                    $this->bob
+                )
+            )
+        ];
+        $registry = $this->instance->calculate(
+            ...$nBallots
+        );
+        // N(N-1)
+        $this->assertEquals(6, $registry->getCount());
+        //check that tied candidates' margins reflect that they are tied
+        $this->assertEquals(0, $registry->get($this->alice, $this->bob)->getMargin());
+        $this->assertEquals(0, $registry->get($this->bob, $this->alice)->getMargin());
+        //check that the margins indicate that Claire is ahead of Alice and Bob
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->alice, $this->claire)->getMargin());
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->bob, $this->claire)->getMargin());
+        $this->assertEquals($ballotCount, $registry->get($this->claire, $this->alice)->getMargin());
+        $this->assertEquals($ballotCount, $registry->get($this->claire, $this->bob)->getMargin());
+    }
+    public function testCalculateForThreeNonTiedCandidates() : void
+    {
+        $ballotCount = 7;
+        $nBallots = [
+            new NBallot(
+                $ballotCount,
+                new CandidateList(
+                    $this->claire
+                ),
+                new CandidateList(
+                    $this->alice
+                ),
+                new CandidateList(
+                    $this->bob
+                )
+            )
+        ];
+        $registry = $this->instance->calculate(
+            ...$nBallots
+        );
+        // N(N-1)
+        $this->assertEquals(6, $registry->getCount());
+
+        //Now check all N(N-1) margins in the registry
+
+        //check that Claire is ranked higher than Alice
+        $this->assertEquals($ballotCount, $registry->get($this->claire, $this->alice)->getMargin());
+        //check that Alice is ranked lower than Claire
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->alice, $this->claire)->getMargin());
+        //check that Claire is ranked higher than Bob
+        $this->assertEquals($ballotCount, $registry->get($this->claire, $this->bob)->getMargin());
+        //check that Bob is ranked lower than Claire
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->bob, $this->claire)->getMargin());
+        //check that Alice is ranked higher than Bob
+        $this->assertEquals($ballotCount, $registry->get($this->claire, $this->alice)->getMargin());
+        //check that Bob is ranked lower than Alice
+        $this->assertEquals(-1 * $ballotCount, $registry->get($this->bob, $this->alice)->getMargin());
     }
 }


### PR DESCRIPTION
This pull request should finish off #7.

Previously only very simple cases of the MarginCalculator.calculate() method were covered by tests. This pull request introduces a few more cases.

Limits to this testing approach:
A fully comprehensive test verifies the correctness of every Margin in the MarginRegistry returned by MarginCalculator.calcluate(). The number of Margins in that registry is N(N-1) where `N` is the number of Candidates in the Ballot passed to calculate(). While it is good to add test cases, we cannot expect to add too many more fully comprehensive test cases because the number of Margins to check quickly becomes too large for even small numbers of Candidates. Future tests for this method that have larger numbers of Candidates will likely involve non-comprehensive spot-checks, and/or [results from existing data sets](https://github.com/pivot-libre/tideman/issues/30).