### PR TITLE
Added some logging infrastructure

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,7 +3,7 @@
 <project name="tideman" default="build">
 
     <target name="build" depends="lint,phpstan,phpcs,phpunit" />
-    <target name="build-ci" depends="lint,phpstan,phpcs,phpunit-ci" />
+    <target name="build-ci" depends="lint,phpstan,phpcs,phpunit-ci,print-logs" />
     <target name="test" depends="phpunit" />
     <target name="coverage" depends="phpunit-coverage" />
 
@@ -27,6 +27,11 @@
                 <include name="**/*.php" />
             </fileset>
         </phplint>
+    </target>
+
+    <target name="print-logs" description="print build logs">
+       <loadfile property="log-output" file="build/logs/out.log" />
+       <echo message="${log-output}" />
     </target>
 
     <target name="phpcs" description="Find coding standard violations using PHP_CodeSniffer">

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,8 @@
     "require": {
         "psr/log": "^1.0.2",
         "clue/graph": "0.9.0",
-        "graphp/algorithms": "0.8.1"
+        "graphp/algorithms": "0.8.1",
+        "bitexpert/slf4psrlog": "^0.1.3"
     },
     "require-dev": {
         "cadre/sniffs": "^0.1.0",

--- a/src/TieBreakingMarginComparator.php
+++ b/src/TieBreakingMarginComparator.php
@@ -1,18 +1,17 @@
 <?php
 namespace PivotLibre\Tideman;
 
-use Psr\Log\LoggerAwareInterface;
-use Psr\Log\LoggerAwareTrait;
+use \bitExpert\Slf4PsrLog\LoggerFactory;
 
 class TieBreakingMarginComparator
 {
 
-    use LoggerAwareTrait;
-
     private $tieBreaker;
+    private $logger;
 
     public function __construct(MarginTieBreaker $tieBreaker)
     {
+        $this->logger = LoggerFactory::getLogger(__CLASS__);
         $this->tieBreaker = $tieBreaker;
     }
 
@@ -32,13 +31,11 @@ class TieBreakingMarginComparator
     {
         $differenceOfStrength = $b->getDifference() - $a->getDifference();
         if (0 == $differenceOfStrength) {
-            // $this->logger->info("Tie between two Margins:\n$a\n$b\n");
-            echo "Tie between two Margins:\n$a\n$b\n";
+            $this->logger->notice("Tie between two Margins:\n$a\n$b\n");
             $result = $this->tieBreaker->breakTie($a, $b);
             $winner = $result > 0 ? $a : $b;
             $loser = $result > 0 ? $b : $a;
-            // $this->logger->info("Tie-breaking results:\nWinner:\n$winner\nLoser:\n$loser\n");
-            echo "Tie-breaking results:\nWinner:\n$winner\nLoser:\n$loser\n";
+            $this->logger->notice("Tie-breaking results:\nWinner:\n$winner\nLoser:\n$loser\n");
         } else {
             $result = $differenceOfStrength;
         }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,3 +14,12 @@ php composer.phar install
 EOT
     );
 }
+
+\bitExpert\Slf4PsrLog\LoggerFactory::registerFactoryCallback(function ($channel) {
+    if (!\Monolog\Registry::hasLogger($channel)) {
+        $logger = new \Monolog\Logger($channel);
+        $logger->pushHandler(new \Monolog\Handler\StreamHandler('build/logs/out.log'));
+        \Monolog\Registry::addLogger($logger);
+    }
+    return \Monolog\Registry::getInstance($channel);
+});


### PR DESCRIPTION
I added logging to an existing class, added logging setup to the tests' bootstrap, and added log printing as a build target.

I reviewed the options for injecting logging on Andrew's handy blog post.
https://www.futureproofphp.com/2017/03/06/best-way-inject-logger/
I enjoyed the comments section too.

I tried the different approaches. I liked how the SLF4PSR approach:
 1. decouples the code from particular PSR-compliant logger implementations
 2. permits someone to use the tideman library without a dependency injection framework, and without the busy work of constructing and passing in loggers to many instances.
 3. permits someone uninterested in logging to quickly specify the PSR NullLogger in one place.

The caveats are that this doesn't seem to be the approach that is widely used in the PHP community, and it requires an additional dependency on the standard logging facade package, which, while small, and not in imminent need of any features, doesn't have a lot of activity on GitHub.

I'm wondering if we could clear up at least two points of ignorance on my part.

Do we know at this point whether it will be easy to integrate this into the Laravel app? I'm guessing the answer is "no, let's try it!", but we can certainly take another approach )

Is there something that I'm not grasping that makes the injection-based logging more attractive? I haven't used a dependency injection framework in PHP for a long time -> Symfony, 5 years ago.