### PR TITLE
Added NBallot multiplier parsing

### DIFF
--- a/src/BallotParser.php
+++ b/src/BallotParser.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace PivotLibre\Tideman;
+
+class BallotParser
+{
+    private $parser;
+    public function __construct()
+    {
+        $this->parser = new CandidateRankingParser();
+    }
+
+    public function parse(string $text) : Ballot
+    {
+        $candidateRanking = $this->parser->parse($text);
+        $ballot = new Ballot(...$candidateRanking);
+        return $ballot;
+    }
+}

--- a/src/CandidateRankingParser.php
+++ b/src/CandidateRankingParser.php
@@ -9,6 +9,10 @@ class CandidateRankingParser
 {
     private const ORDERED_DELIM = ">";
     private const EQUAL_DELIM = "=";
+    private const PROHIBITED_CHARACTERS = [
+      '<', // only one direction of comparison is supported
+      '*', // asterisks are used elsewhere to separate a ballot from how many times the same ballot occurred
+    ];
 
     /**
      * @param string $text
@@ -18,6 +22,7 @@ class CandidateRankingParser
      */
     public function parse(string $text) : CandidateRanking
     {
+        $this->throwIfProhibitedCharactersPresent($text);
         $listOfCandidateLists = [];
         $orderedTokens = $this->tokenize($text, self::ORDERED_DELIM);
 
@@ -65,5 +70,30 @@ class CandidateRankingParser
                 "Error parsing ranking of Candidates -- found blank where candidate id was expected"
             );
         }
+    }
+
+    /**
+     * @param string $text
+     * @throws InvalidArgumentException if $text contains anything in CandidateRankingParser::PROHIBITED_CHARACTERS
+     */
+    private function throwIfProhibitedCharactersPresent(string $text) : void
+    {
+        foreach (CandidateRankingParser::PROHIBITED_CHARACTERS as $prohibitedCharacter) {
+            if ($this->contains($prohibitedCharacter, $text)) {
+                throw new InvalidArgumentException(
+                    "Found illegal character '$prohibitedCharacter' in string '$text'"
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string $needle
+     * @param string $haystack
+     * @return bool - true if $needle in $haystack, false otherwise
+     */
+    private function contains(string $needle, string $haystack)
+    {
+        return strpos($haystack, $needle) !== false;
     }
 }

--- a/src/NBallotParser.php
+++ b/src/NBallotParser.php
@@ -8,7 +8,7 @@ use \InvalidArgumentException;
 class NBallotParser
 {
     private $parser;
-
+    public const OPTIONAL_MULTIPLIER = "*";
     public function __construct()
     {
         $this->parser = new CandidateRankingParser();
@@ -22,8 +22,55 @@ class NBallotParser
      */
     public function parse(string $text) : NBallot
     {
-        $candidateRanking = $this->parser->parse($text);
-        $ballot = new NBallot(1, ...$candidateRanking);
+        //default n to one
+        $n = 1;
+        $tokens = $this->tokenize($text);
+        if (2 === sizeof($tokens)) {
+            $nToken = $tokens[0];
+            $rankingToken = $tokens[1];
+
+            $n = $this->parseN($nToken);
+            $candidateRanking = $this->parser->parse($rankingToken);
+        } elseif (1 === sizeof($tokens)) {
+            $candidateRanking = $this->parser->parse($tokens[0]);
+        } else {
+            $msg = "Could not parse NBallot. Got '$text'. Expected things like 'A>B=C', '1 * A>B>C', or '42*C=B>A'.";
+            throw new InvalidArgumentException($msg);
+        }
+        $ballot = new NBallot($n, ...$candidateRanking);
         return $ballot;
+    }
+
+    /**
+     * @param string $text
+     * @return array of trimmed string tokens
+     */
+    private function tokenize(string $text) : array
+    {
+        $tokens = explode(NBallotParser::OPTIONAL_MULTIPLIER, $text);
+        $tokens = array_map(function ($token) {
+            return trim($token);
+        }, $tokens);
+        return $tokens;
+    }
+
+    /**
+     * @param string $text
+     * @return int the positive integer counting the number of times this Ballot occurs
+     */
+    private function parseN(string $text) : int
+    {
+        $n = (int)$text;
+
+        if (floatval($text) != intval($text)) {
+            throw new InvalidArgumentException("Only integer numbers of ballots are possible. Got '$text'.");
+        }
+
+        if (1 > $n) {
+            $msg = "A ballot can only be represented a positive integer number of times. Got '$text' instead";
+            throw new InvalidArgumentException($msg);
+        }
+
+        return $n;
     }
 }

--- a/tests/BallotParserTest.php
+++ b/tests/BallotParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PivotLibre\Tideman;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BallotParserTest
+ * Presently, the BallotParser is just a thin wrapper around the CandidateRankingParser. We can safely perform minimal
+ * testing here because most functionality is extensively tested in CandidateRankingParserTest.
+ * @package PivotLibre\Tideman
+ */
+class BallotParserTest extends TestCase
+{
+    private $instance;
+    private $alice;
+    private $bob;
+    private $claire;
+
+    public function setUp()
+    {
+        $this->instance = new BallotParser();
+        $this->alice = new Candidate("A");
+        $this->bob = new Candidate("B");
+        $this->claire = new Candidate("C");
+    }
+
+    public function testGoodBallot()
+    {
+        $expected = new Ballot(
+            new CandidateList($this->alice),
+            new CandidateList($this->bob),
+            new CandidateList($this->claire)
+        );
+
+        $actual = $this->instance->parse("A>B>C");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testThatAsteriskBreaks()
+    {
+        //BallotParser should not parse NBallot text
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("1*A>B>C");
+    }
+}

--- a/tests/CandidateRankingParserTest.php
+++ b/tests/CandidateRankingParserTest.php
@@ -218,4 +218,18 @@ class CandidateRankingParserTest extends TestCase
         $actual = $this->instance->parse("A=B=C=D>E");
         $this->assertEquals($expected, $actual);
     }
+
+    public function testBallotWithWrongAngleBracket() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("A<B");
+    }
+
+    public function testUnexpectedNBallotText() : void
+    {
+        //We should not successfully parse anything that should be parsed by NBallotParser, so we error out if we see
+        //anything with an asterisk.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("3*A>B>C");
+    }
 }

--- a/tests/NBallotParserTest.php
+++ b/tests/NBallotParserTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace PivotLibre\Tideman;
+
+use PHPUnit\Framework\TestCase;
+
+class NBallotParserTest extends TestCase
+{
+    private $instance;
+    private $alice;
+    private $bob;
+    private $claire;
+
+    public function setUp()
+    {
+        $this->instance = new NBallotParser();
+        $this->alice = new Candidate("A");
+        $this->bob = new Candidate("B");
+        $this->claire = new Candidate("C");
+    }
+
+    public function testGoodText()
+    {
+        $expected = new NBallot(
+            3,
+            new CandidateList($this->alice),
+            new CandidateList($this->bob),
+            new CandidateList($this->claire)
+        );
+
+        $actual = $this->instance->parse("3*A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        //try with various spaces
+        $actual = $this->instance->parse(" 3*A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse("3 *A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse("3* A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse("3 * A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse(" 3 * A>B>C");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testThatMultiplierIsOptional()
+    {
+        $expected = new NBallot(
+            1,
+            new CandidateList($this->alice),
+            new CandidateList($this->claire),
+            new CandidateList($this->bob)
+        );
+
+        $actual = $this->instance->parse("A>C>B");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testThatZeroBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("0*A>B>C");
+    }
+
+    public function testThatNegativeZeroBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-0*A>B>C");
+    }
+
+    public function testThatPositiveZeroBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("+0*A>B>C");
+    }
+
+    public function testThatNegativeOneBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-1*A>B>C");
+    }
+
+    public function testThatNegativeIntegersBreak()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-3*A>B>C");
+    }
+
+    public function testThatPositiveFloatNumberBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("3.14159*A>B>C");
+    }
+
+    public function testThatNegativeFloatNumberBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-3.14159*A>B>C");
+    }
+
+    public function testDoubleMultiplierBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("2*2*A>B>C");
+    }
+
+    public function testDisconnectedMultiplierBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("2*A>B>C*2");
+    }
+
+    public function testTrailingMultiplierBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("A>B>C*2");
+    }
+
+    public function testBlankBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("");
+    }
+}


### PR DESCRIPTION
Addresses #90 
This work makes it easy to concisely simulate elections, which will help implement #52 and https://github.com/pivot-libre/pivot/issues/156.

Later, if/when we remove the NBallot class, the NBallot Parser can be retained. It will simply return an array of N regular Ballot instances instead of one NBallot instance.