### PR TITLE
Final ranking tests#52

### DIFF
--- a/src/BallotParser.php
+++ b/src/BallotParser.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace PivotLibre\Tideman;
+
+class BallotParser
+{
+    private $parser;
+    public function __construct()
+    {
+        $this->parser = new CandidateRankingParser();
+    }
+
+    public function parse(string $text) : Ballot
+    {
+        $candidateRanking = $this->parser->parse($text);
+        $ballot = new Ballot(...$candidateRanking);
+        return $ballot;
+    }
+}

--- a/src/CandidateRankingParser.php
+++ b/src/CandidateRankingParser.php
@@ -9,6 +9,10 @@ class CandidateRankingParser
 {
     private const ORDERED_DELIM = ">";
     private const EQUAL_DELIM = "=";
+    private const PROHIBITED_CHARACTERS = [
+      '<', // only one direction of comparison is supported
+      '*', // asterisks are used elsewhere to separate a ballot from how many times the same ballot occurred
+    ];
 
     /**
      * @param string $text
@@ -18,6 +22,7 @@ class CandidateRankingParser
      */
     public function parse(string $text) : CandidateRanking
     {
+        $this->throwIfProhibitedCharactersPresent($text);
         $listOfCandidateLists = [];
         $orderedTokens = $this->tokenize($text, self::ORDERED_DELIM);
 
@@ -65,5 +70,30 @@ class CandidateRankingParser
                 "Error parsing ranking of Candidates -- found blank where candidate id was expected"
             );
         }
+    }
+
+    /**
+     * @param string $text
+     * @throws InvalidArgumentException if $text contains anything in CandidateRankingParser::PROHIBITED_CHARACTERS
+     */
+    private function throwIfProhibitedCharactersPresent(string $text) : void
+    {
+        foreach (CandidateRankingParser::PROHIBITED_CHARACTERS as $prohibitedCharacter) {
+            if ($this->contains($prohibitedCharacter, $text)) {
+                throw new InvalidArgumentException(
+                    "Found illegal character '$prohibitedCharacter' in string '$text'"
+                );
+            }
+        }
+    }
+
+    /**
+     * @param string $needle
+     * @param string $haystack
+     * @return bool - true if $needle in $haystack, false otherwise
+     */
+    private function contains(string $needle, string $haystack)
+    {
+        return strpos($haystack, $needle) !== false;
     }
 }

--- a/src/NBallotParser.php
+++ b/src/NBallotParser.php
@@ -8,7 +8,7 @@ use \InvalidArgumentException;
 class NBallotParser
 {
     private $parser;
-
+    public const OPTIONAL_MULTIPLIER = "*";
     public function __construct()
     {
         $this->parser = new CandidateRankingParser();
@@ -22,8 +22,55 @@ class NBallotParser
      */
     public function parse(string $text) : NBallot
     {
-        $candidateRanking = $this->parser->parse($text);
-        $ballot = new NBallot(1, ...$candidateRanking);
+        //default n to one
+        $n = 1;
+        $tokens = $this->tokenize($text);
+        if (2 === sizeof($tokens)) {
+            $nToken = $tokens[0];
+            $rankingToken = $tokens[1];
+
+            $n = $this->parseN($nToken);
+            $candidateRanking = $this->parser->parse($rankingToken);
+        } elseif (1 === sizeof($tokens)) {
+            $candidateRanking = $this->parser->parse($tokens[0]);
+        } else {
+            $msg = "Could not parse NBallot. Got '$text'. Expected things like 'A>B=C', '1 * A>B>C', or '42*C=B>A'.";
+            throw new InvalidArgumentException($msg);
+        }
+        $ballot = new NBallot($n, ...$candidateRanking);
         return $ballot;
+    }
+
+    /**
+     * @param string $text
+     * @return array of trimmed string tokens
+     */
+    private function tokenize(string $text) : array
+    {
+        $tokens = explode(NBallotParser::OPTIONAL_MULTIPLIER, $text);
+        $tokens = array_map(function ($token) {
+            return trim($token);
+        }, $tokens);
+        return $tokens;
+    }
+
+    /**
+     * @param string $text
+     * @return int the positive integer counting the number of times this Ballot occurs
+     */
+    private function parseN(string $text) : int
+    {
+        $n = (int)$text;
+
+        if (floatval($text) != intval($text)) {
+            throw new InvalidArgumentException("Only integer numbers of ballots are possible. Got '$text'.");
+        }
+
+        if (1 > $n) {
+            $msg = "A ballot can only be represented a positive integer number of times. Got '$text' instead";
+            throw new InvalidArgumentException($msg);
+        }
+
+        return $n;
     }
 }

--- a/tests/BallotParserTest.php
+++ b/tests/BallotParserTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace PivotLibre\Tideman;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class BallotParserTest
+ * Presently, the BallotParser is just a thin wrapper around the CandidateRankingParser. We can safely perform minimal
+ * testing here because most functionality is extensively tested in CandidateRankingParserTest.
+ * @package PivotLibre\Tideman
+ */
+class BallotParserTest extends TestCase
+{
+    private $instance;
+    private $alice;
+    private $bob;
+    private $claire;
+
+    public function setUp()
+    {
+        $this->instance = new BallotParser();
+        $this->alice = new Candidate("A");
+        $this->bob = new Candidate("B");
+        $this->claire = new Candidate("C");
+    }
+
+    public function testGoodBallot()
+    {
+        $expected = new Ballot(
+            new CandidateList($this->alice),
+            new CandidateList($this->bob),
+            new CandidateList($this->claire)
+        );
+
+        $actual = $this->instance->parse("A>B>C");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testThatAsteriskBreaks()
+    {
+        //BallotParser should not parse NBallot text
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("1*A>B>C");
+    }
+}

--- a/tests/CandidateRankingParserTest.php
+++ b/tests/CandidateRankingParserTest.php
@@ -218,4 +218,18 @@ class CandidateRankingParserTest extends TestCase
         $actual = $this->instance->parse("A=B=C=D>E");
         $this->assertEquals($expected, $actual);
     }
+
+    public function testBallotWithWrongAngleBracket() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("A<B");
+    }
+
+    public function testUnexpectedNBallotText() : void
+    {
+        //We should not successfully parse anything that should be parsed by NBallotParser, so we error out if we see
+        //anything with an asterisk.
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("3*A>B>C");
+    }
 }

--- a/tests/NBallotParserTest.php
+++ b/tests/NBallotParserTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace PivotLibre\Tideman;
+
+use PHPUnit\Framework\TestCase;
+
+class NBallotParserTest extends TestCase
+{
+    private $instance;
+    private $alice;
+    private $bob;
+    private $claire;
+
+    public function setUp()
+    {
+        $this->instance = new NBallotParser();
+        $this->alice = new Candidate("A");
+        $this->bob = new Candidate("B");
+        $this->claire = new Candidate("C");
+    }
+
+    public function testGoodText()
+    {
+        $expected = new NBallot(
+            3,
+            new CandidateList($this->alice),
+            new CandidateList($this->bob),
+            new CandidateList($this->claire)
+        );
+
+        $actual = $this->instance->parse("3*A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        //try with various spaces
+        $actual = $this->instance->parse(" 3*A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse("3 *A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse("3* A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse("3 * A>B>C");
+        $this->assertEquals($expected, $actual);
+
+        $actual = $this->instance->parse(" 3 * A>B>C");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testThatMultiplierIsOptional()
+    {
+        $expected = new NBallot(
+            1,
+            new CandidateList($this->alice),
+            new CandidateList($this->claire),
+            new CandidateList($this->bob)
+        );
+
+        $actual = $this->instance->parse("A>C>B");
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testThatZeroBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("0*A>B>C");
+    }
+
+    public function testThatNegativeZeroBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-0*A>B>C");
+    }
+
+    public function testThatPositiveZeroBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("+0*A>B>C");
+    }
+
+    public function testThatNegativeOneBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-1*A>B>C");
+    }
+
+    public function testThatNegativeIntegersBreak()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-3*A>B>C");
+    }
+
+    public function testThatPositiveFloatNumberBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("3.14159*A>B>C");
+    }
+
+    public function testThatNegativeFloatNumberBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("-3.14159*A>B>C");
+    }
+
+    public function testDoubleMultiplierBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("2*2*A>B>C");
+    }
+
+    public function testDisconnectedMultiplierBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("2*A>B>C*2");
+    }
+
+    public function testTrailingMultiplierBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("A>B>C*2");
+    }
+
+    public function testBlankBreaks()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->instance->parse("");
+    }
+}

--- a/tests/RankedPairsCalculatorTest.php
+++ b/tests/RankedPairsCalculatorTest.php
@@ -234,4 +234,18 @@ class RankedPairsCalculatorTest extends TestCase
         $expectedWinners = new CandidateList($this->claire, $this->bob, $this->alice);
         $this->assertEquals($expectedWinners, $actualWinners->getRanking());
     }
+
+    public function testTideman1987Example5()
+    {
+        $expectedRanking = (new CandidateRankingParser())->parse("V>W>X>Y>Z");
+
+        $ballots = (new TestScenarioTideman1987Example2())->getBallots();
+        $tieBreakingBallot = $ballots[0];
+
+        $instance = new RankedPairsCalculator($tieBreakingBallot);
+        $results = $instance->calculate(sizeof($ballots), ...$ballots);
+        $actualRanking = $results->getRanking();
+
+        $this->assertEquals($expectedRanking, $actualRanking);
+    }
 }

--- a/tests/RankedPairsCalculatorTest.php
+++ b/tests/RankedPairsCalculatorTest.php
@@ -252,6 +252,8 @@ class RankedPairsCalculatorTest extends TestCase
     /**
      * Scenario 1 from the test spreadsheet
      * https://docs.google.com/spreadsheets/d/1634wP6-N8GG2Fig-yjIOk7vPBn4AijXOrjq6Z2T1K8M/edit?usp=sharing
+     * Drawing of graph:
+     * https://docs.google.com/drawings/d/1mtGlWgqr_h85qdvqSjC9eK0bRzbGYas-sLhuzAiDd3I/edit?usp=sharing
      */
     public function testScenario1()
     {

--- a/tests/RankedPairsCalculatorTest.php
+++ b/tests/RankedPairsCalculatorTest.php
@@ -268,4 +268,23 @@ class RankedPairsCalculatorTest extends TestCase
 
         $this->assertEquals($expectedRanking, $actualRanking);
     }
+
+    /**
+     * Scenario 2 from the test spreadsheet
+     * https://docs.google.com/spreadsheets/d/1634wP6-N8GG2Fig-yjIOk7vPBn4AijXOrjq6Z2T1K8M/edit?usp=sharing
+     */
+    public function testScenario2()
+    {
+        $expectedRanking = (new CandidateRankingParser())->parse("MM>BT>FE=CS>RR");
+
+        $ballots = (new TestScenario2())->getBallots();
+        $tieBreakingBallot = $ballots[0];
+
+        $instance = new RankedPairsCalculator($tieBreakingBallot);
+        $results = $instance->calculate(sizeof($ballots), ...$ballots);
+        $actualRanking = $results->getRanking();
+
+        $this->assertEquals($expectedRanking, $actualRanking);
+    }
+
 }

--- a/tests/RankedPairsCalculatorTest.php
+++ b/tests/RankedPairsCalculatorTest.php
@@ -304,4 +304,22 @@ class RankedPairsCalculatorTest extends TestCase
 
         $this->assertEquals($expectedRanking, $actualRanking);
     }
+
+    /**
+     * Scenario 4 from the test spreadsheet
+     * https://docs.google.com/spreadsheets/d/1634wP6-N8GG2Fig-yjIOk7vPBn4AijXOrjq6Z2T1K8M/edit?usp=sharing
+     */
+    public function testScenario4()
+    {
+        $expectedRanking = (new CandidateRankingParser())->parse("CW>BB>CS>BT=SY");
+
+        $ballots = (new TestScenario4())->getBallots();
+        $tieBreakingBallot = $ballots[0];
+
+        $instance = new RankedPairsCalculator($tieBreakingBallot);
+        $results = $instance->calculate(sizeof($ballots), ...$ballots);
+        $actualRanking = $results->getRanking();
+
+        $this->assertEquals($expectedRanking, $actualRanking);
+    }
 }

--- a/tests/RankedPairsCalculatorTest.php
+++ b/tests/RankedPairsCalculatorTest.php
@@ -248,4 +248,22 @@ class RankedPairsCalculatorTest extends TestCase
 
         $this->assertEquals($expectedRanking, $actualRanking);
     }
+
+    /**
+     * Scenario 1 from the test spreadsheet
+     * https://docs.google.com/spreadsheets/d/1634wP6-N8GG2Fig-yjIOk7vPBn4AijXOrjq6Z2T1K8M/edit?usp=sharing
+     */
+    public function testScenario1()
+    {
+        $expectedRanking = (new CandidateRankingParser())->parse("MM>SY=DD>YW>RR");
+
+        $ballots = (new TestScenario1())->getBallots();
+        $tieBreakingBallot = $ballots[0];
+
+        $instance = new RankedPairsCalculator($tieBreakingBallot);
+        $results = $instance->calculate(sizeof($ballots), ...$ballots);
+        $actualRanking = $results->getRanking();
+
+        $this->assertEquals($expectedRanking, $actualRanking);
+    }
 }

--- a/tests/RankedPairsCalculatorTest.php
+++ b/tests/RankedPairsCalculatorTest.php
@@ -287,4 +287,21 @@ class RankedPairsCalculatorTest extends TestCase
         $this->assertEquals($expectedRanking, $actualRanking);
     }
 
+    /**
+     * Scenario 3 from the test spreadsheet
+     * https://docs.google.com/spreadsheets/d/1634wP6-N8GG2Fig-yjIOk7vPBn4AijXOrjq6Z2T1K8M/edit?usp=sharing
+     */
+    public function testScenario3()
+    {
+        $expectedRanking = (new CandidateRankingParser())->parse("MN>MC>BT>FE=CS>RR");
+
+        $ballots = (new TestScenario3())->getBallots();
+        $tieBreakingBallot = $ballots[0];
+
+        $instance = new RankedPairsCalculator($tieBreakingBallot);
+        $results = $instance->calculate(sizeof($ballots), ...$ballots);
+        $actualRanking = $results->getRanking();
+
+        $this->assertEquals($expectedRanking, $actualRanking);
+    }
 }


### PR DESCRIPTION
This PR addresses #52. This adds one final ranking test from the Tideman Zavist 1987 paper and four of the five tests from the test scenario spreadsheet.

The remaining test in the spreadsheet has a lot of edge ties so I'm guessing it will be harder to debug. I won't have much time to work on this the next few days. In the mean time it would be good to get these other tests merged so that they can run against other functionality that might be incorporated like any bug fixes that arise from the random graph generation.

This pull request builds off of commits in #91. It will be easier to review once #91 is merged.